### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "empress-blueprint-helpers",
   "version": "1.2.0",
   "repository": "https://github.com/empress/empress-blueprint-helpers",
+  "license": "MIT",
   "scripts": {
     "lint": "eslint .",
     "test": "NODE_ENV=test mocha --recursive --reporter spec",


### PR DESCRIPTION
MIT is specified on GitHub and in LICENSE.md, but it's missing in the package file. This field is used for license validations by some consumers and will be read as UNLICENSED otherwise.